### PR TITLE
feat: add extraFields option for custom response schema fields

### DIFF
--- a/examples/src/config/custom-swagger-builder.ts
+++ b/examples/src/config/custom-swagger-builder.ts
@@ -4,3 +4,18 @@ export const CustomSwaggerBuilder = new ApiDecoratorBuilder({
   statusKey: "status",
   wrapperKey: "data",
 });
+
+export const SuccessSwaggerBuilder = new ApiDecoratorBuilder({
+  extraFields: {
+    success: { type: "boolean", example: true },
+  },
+  wrapperKey: "data",
+});
+
+export const StandardSwaggerBuilder = new ApiDecoratorBuilder({
+  extraFields: {
+    success: { type: "boolean", example: true },
+    message: { type: "string", example: "OK" },
+  },
+  wrapperKey: "result",
+});

--- a/examples/src/controllers/swagger/user.swagger.ts
+++ b/examples/src/controllers/swagger/user.swagger.ts
@@ -1,15 +1,18 @@
 import { HttpStatus } from "@nestjs/common";
 import { ApiDecoratorBuilder, ApiOperator } from "nest-swagger-builder";
-import { CustomSwaggerBuilder } from "src/config/custom-swagger-builder";
+import {
+  CustomSwaggerBuilder,
+  SuccessSwaggerBuilder,
+  StandardSwaggerBuilder,
+} from "src/config/custom-swagger-builder";
 import { UserController } from "src/controllers/user.controller";
 import { UserDto } from "src/dto/user.dto";
 
 export const ApiUser: ApiOperator<keyof UserController> = {
   CreateUser: (apiOperationOptions) => {
-    return new ApiDecoratorBuilder()
-      .withOperation(apiOperationOptions)
+    return StandardSwaggerBuilder.withOperation(apiOperationOptions)
       .withBearerAuth()
-      .withStatusResponse(HttpStatus.CREATED, "ApiUser_CreateUser")
+      .withBodyResponse(HttpStatus.CREATED, "ApiUser_CreateUser", UserDto)
       .withException(HttpStatus.BAD_REQUEST, [
         { error: "error1", description: "description1" },
         { error: "error2", description: "description2" },
@@ -22,12 +25,12 @@ export const ApiUser: ApiOperator<keyof UserController> = {
   },
 
   GetUsers: (apiOperationOptions) => {
-    return new ApiDecoratorBuilder()
-      .withOperation(apiOperationOptions)
+    return SuccessSwaggerBuilder.withOperation(apiOperationOptions)
       .withCookieAuth()
       .withBodyResponse(HttpStatus.OK, "ApiUser_GetUsers", [UserDto], {
-        statusKey: "status",
-        wrapperKey: "data",
+        extraFields: {
+          totalCount: { type: "number", example: 50 },
+        },
       })
       .build();
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  transform: {
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        tsconfig: {
+          experimentalDecorators: true,
+          emitDecoratorMetadata: true,
+        },
+      },
+    ],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-swagger-builder",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A utility library that simplifies the NestJS Swagger documentation process.",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build",
     "clean": "rimraf dist",
     "prebuild": "npm run clean",
-    "test": "echo \"No tests specified\" && exit 0",
+    "test": "jest",
     "prepare": "npm run build"
   },
   "keywords": [
@@ -37,8 +37,11 @@
   "devDependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/swagger": "^7.0.0",
+    "@types/jest": "^30.0.0",
     "@types/node": "^20.10.0",
+    "jest": "^30.2.0",
     "rimraf": "^5.0.5",
+    "ts-jest": "^29.4.6",
     "typescript": "^5.3.0"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-swagger-builder",
-  "version": "1.1.0",
+  "version": "1.1.0-beta.0",
   "description": "A utility library that simplifies the NestJS Swagger documentation process.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-swagger-builder",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0-beta.1",
   "description": "A utility library that simplifies the NestJS Swagger documentation process.",
   "repository": {
     "type": "git",

--- a/src/builders/__tests__/api-decorator.builder.spec.ts
+++ b/src/builders/__tests__/api-decorator.builder.spec.ts
@@ -289,3 +289,62 @@ describe("ApiDecoratorBuilder - extraFields", () => {
     expect(meta.isArray).toBe(true);
   });
 });
+
+describe("ApiDecoratorBuilder - withException name fallback & content-type", () => {
+  function getExceptionContent(target: any, status: number): any {
+    const responses = getMethodMeta(target, SWAGGER_API_RESPONSE);
+    return responses?.[status.toString()]?.content;
+  }
+
+  it("should use error code as examples key when name is omitted", () => {
+    const decorator = new ApiDecoratorBuilder()
+      .withException(400, [{ error: "INVALID_INPUT" }, { error: "MISSING_FIELD" }])
+      .build();
+
+    const Target = applyDecoratorToMethod(decorator);
+    const content = getExceptionContent(Target, 400);
+
+    expect(content["application/json"]).toBeDefined();
+    expect(Object.keys(content["application/json"].examples)).toEqual([
+      "INVALID_INPUT",
+      "MISSING_FIELD",
+    ]);
+  });
+
+  it("should use explicit name as examples key when provided", () => {
+    const decorator = new ApiDecoratorBuilder()
+      .withException(400, [{ name: "InvalidFile", error: "INVALID_INPUT" }])
+      .build();
+
+    const Target = applyDecoratorToMethod(decorator);
+    const content = getExceptionContent(Target, 400);
+
+    expect(Object.keys(content["application/json"].examples)).toEqual(["InvalidFile"]);
+  });
+
+  it("should mix name and error fallbacks within the same call", () => {
+    const decorator = new ApiDecoratorBuilder()
+      .withException(400, [
+        { name: "Case1", error: "ERR_A" },
+        { error: "ERR_B" },
+      ])
+      .build();
+
+    const Target = applyDecoratorToMethod(decorator);
+    const content = getExceptionContent(Target, 400);
+
+    expect(Object.keys(content["application/json"].examples)).toEqual(["Case1", "ERR_B"]);
+  });
+
+  it("should expose examples under application/json (not the legacy application-json typo)", () => {
+    const decorator = new ApiDecoratorBuilder()
+      .withException(400, [{ error: "X" }])
+      .build();
+
+    const Target = applyDecoratorToMethod(decorator);
+    const content = getExceptionContent(Target, 400);
+
+    expect(content["application/json"]).toBeDefined();
+    expect(content["application-json"]).toBeUndefined();
+  });
+});

--- a/src/builders/__tests__/api-decorator.builder.spec.ts
+++ b/src/builders/__tests__/api-decorator.builder.spec.ts
@@ -1,0 +1,291 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { ApiDecoratorBuilder } from "../api-decorator.builder";
+
+const SWAGGER_API_OPERATION = "swagger/apiOperation";
+const SWAGGER_API_SECURITY = "swagger/apiSecurity";
+const SWAGGER_API_RESPONSE = "swagger/apiResponse";
+const SWAGGER_API_MODEL_PROPERTIES = "swagger/apiModelProperties";
+const SWAGGER_API_MODEL_PROPERTIES_ARRAY = "swagger/apiModelPropertiesArray";
+
+function applyDecoratorToMethod(
+  decorator: MethodDecorator | PropertyDecorator
+) {
+  class Target {
+    method() {}
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(
+    Target.prototype,
+    "method"
+  )!;
+  (decorator as MethodDecorator)(Target.prototype, "method", descriptor);
+  Object.defineProperty(Target.prototype, "method", descriptor);
+  return Target;
+}
+
+function getMethodMeta(target: any, key: string) {
+  const descriptor = Object.getOwnPropertyDescriptor(target.prototype, "method");
+  return Reflect.getMetadata(key, descriptor!.value);
+}
+
+function getResponseType(target: any, status: number): any {
+  const responses = getMethodMeta(target, SWAGGER_API_RESPONSE);
+  if (!responses) return undefined;
+  const entry = responses[status.toString()];
+  return entry?.type;
+}
+
+function getPropertyMeta(prototype: any, propertyKey: string): any {
+  return Reflect.getMetadata(SWAGGER_API_MODEL_PROPERTIES, prototype, propertyKey);
+}
+
+function getPropertyKeys(prototype: any): string[] {
+  const arr: string[] = Reflect.getMetadata(SWAGGER_API_MODEL_PROPERTIES_ARRAY, prototype) || [];
+  return arr.map((k: string) => k.replace(/^:/, ""));
+}
+
+class TestDto {
+  @ApiProperty({ example: "test" })
+  name!: string;
+}
+
+describe("ApiDecoratorBuilder - build() state reset", () => {
+  it("should reset decorators after build() so second build() has no previous decorators", () => {
+    const builder = new ApiDecoratorBuilder();
+
+    const first = builder.withOperation({ summary: "First" }).build();
+    const FirstTarget = applyDecoratorToMethod(first);
+    const firstMeta = getMethodMeta(FirstTarget, SWAGGER_API_OPERATION);
+
+    expect(firstMeta).toBeDefined();
+    expect(firstMeta.summary).toBe("First");
+
+    const second = builder.withOperation({ summary: "Second" }).build();
+    const SecondTarget = applyDecoratorToMethod(second);
+    const secondMeta = getMethodMeta(SecondTarget, SWAGGER_API_OPERATION);
+
+    expect(secondMeta).toBeDefined();
+    expect(secondMeta.summary).toBe("Second");
+  });
+
+  it("should not accumulate security entries when reusing singleton", () => {
+    const singleton = new ApiDecoratorBuilder();
+
+    for (let i = 0; i < 5; i++) {
+      const decorator = singleton.withBearerAuth().build();
+      const Target = applyDecoratorToMethod(decorator);
+      const security: any[] = getMethodMeta(Target, SWAGGER_API_SECURITY);
+
+      expect(security).toBeDefined();
+      expect(security).toHaveLength(1);
+    }
+  });
+
+  it("should start a clean chain after build()", () => {
+    const builder = new ApiDecoratorBuilder();
+
+    builder.withOperation({ summary: "With Auth" }).withBearerAuth().build();
+
+    const decorator = builder.withOperation({ summary: "No Auth" }).build();
+    const Target = applyDecoratorToMethod(decorator);
+
+    const operation = getMethodMeta(Target, SWAGGER_API_OPERATION);
+    const security = getMethodMeta(Target, SWAGGER_API_SECURITY);
+
+    expect(operation).toBeDefined();
+    expect(operation.summary).toBe("No Auth");
+    expect(security).toBeUndefined();
+  });
+});
+
+describe("ApiDecoratorBuilder - extraFields", () => {
+  it("should apply config extraFields to withBodyResponse schema", () => {
+    const builder = new ApiDecoratorBuilder({
+      extraFields: {
+        success: { type: "boolean", example: true },
+      },
+    });
+
+    const decorator = builder
+      .withBodyResponse(200, "TestConfig", TestDto)
+      .build();
+    const Target = applyDecoratorToMethod(decorator);
+    const ResponseType = getResponseType(Target, 200);
+
+    expect(ResponseType).toBeDefined();
+    const keys = getPropertyKeys(ResponseType.prototype);
+    expect(keys).toContain("success");
+
+    const meta = getPropertyMeta(ResponseType.prototype, "success");
+    expect(meta.type).toBe(Boolean);
+    expect(meta.example).toBe(true);
+  });
+
+  it("should apply per-endpoint extraFields to withBodyResponse schema", () => {
+    const builder = new ApiDecoratorBuilder();
+
+    const decorator = builder
+      .withBodyResponse(200, "TestEndpoint", TestDto, {
+        extraFields: {
+          totalCount: { type: "number", example: 50 },
+        },
+      })
+      .build();
+    const Target = applyDecoratorToMethod(decorator);
+    const ResponseType = getResponseType(Target, 200);
+
+    expect(ResponseType).toBeDefined();
+    const keys = getPropertyKeys(ResponseType.prototype);
+    expect(keys).toContain("totalCount");
+
+    const meta = getPropertyMeta(ResponseType.prototype, "totalCount");
+    expect(meta.type).toBe(Number);
+    expect(meta.example).toBe(50);
+  });
+
+  it("should merge config and endpoint extraFields with endpoint taking priority", () => {
+    const builder = new ApiDecoratorBuilder({
+      extraFields: {
+        success: { type: "boolean", example: true },
+        message: { type: "string", example: "default" },
+      },
+    });
+
+    const decorator = builder
+      .withBodyResponse(200, "TestMerge", TestDto, {
+        extraFields: {
+          message: { type: "string", example: "overridden" },
+          totalCount: { type: "number", example: 10 },
+        },
+      })
+      .build();
+    const Target = applyDecoratorToMethod(decorator);
+    const ResponseType = getResponseType(Target, 200);
+
+    expect(ResponseType).toBeDefined();
+    const keys = getPropertyKeys(ResponseType.prototype);
+    expect(keys).toContain("success");
+    expect(keys).toContain("message");
+    expect(keys).toContain("totalCount");
+
+    const messageMeta = getPropertyMeta(ResponseType.prototype, "message");
+    expect(messageMeta.example).toBe("overridden");
+  });
+
+  it("should create wrapper class with extraFields only (no statusKey/wrapperKey)", () => {
+    const builder = new ApiDecoratorBuilder({
+      extraFields: {
+        success: { type: "boolean", example: true },
+      },
+    });
+
+    const decorator = builder
+      .withBodyResponse(200, "TestOnlyExtra", TestDto)
+      .build();
+    const Target = applyDecoratorToMethod(decorator);
+    const ResponseType = getResponseType(Target, 200);
+
+    expect(ResponseType).toBeDefined();
+    expect(ResponseType.name).toBe("TestOnlyExtraResponseDto");
+
+    const keys = getPropertyKeys(ResponseType.prototype);
+    expect(keys).toContain("success");
+    expect(keys).toContain("data");
+  });
+
+  it("should apply config extraFields to withStatusResponse schema", () => {
+    const builder = new ApiDecoratorBuilder({
+      extraFields: {
+        success: { type: "boolean", example: true },
+      },
+    });
+
+    const decorator = builder
+      .withStatusResponse(200, "TestStatusExtra")
+      .build();
+    const Target = applyDecoratorToMethod(decorator);
+    const ResponseType = getResponseType(Target, 200);
+
+    expect(ResponseType).toBeDefined();
+    const keys = getPropertyKeys(ResponseType.prototype);
+    expect(keys).toContain("success");
+
+    const meta = getPropertyMeta(ResponseType.prototype, "success");
+    expect(meta.type).toBe(Boolean);
+    expect(meta.example).toBe(true);
+  });
+
+  it("should support extraFields combined with wrapperKey", () => {
+    const builder = new ApiDecoratorBuilder({
+      extraFields: {
+        success: { type: "boolean", example: true },
+      },
+      wrapperKey: "result",
+    });
+
+    const decorator = builder
+      .withBodyResponse(200, "TestCombined", TestDto)
+      .build();
+    const Target = applyDecoratorToMethod(decorator);
+    const ResponseType = getResponseType(Target, 200);
+
+    expect(ResponseType).toBeDefined();
+    const keys = getPropertyKeys(ResponseType.prototype);
+    expect(keys).toContain("success");
+    expect(keys).toContain("result");
+  });
+
+  it("should behave as before when no extraFields provided", () => {
+    const builder = new ApiDecoratorBuilder();
+
+    const decorator = builder
+      .withBodyResponse(200, "TestNoExtra", TestDto)
+      .build();
+    const Target = applyDecoratorToMethod(decorator);
+    const ResponseType = getResponseType(Target, 200);
+
+    expect(ResponseType).toBe(TestDto);
+  });
+
+  it("should support Type (class) in extraFields", () => {
+    const builder = new ApiDecoratorBuilder();
+
+    const decorator = builder
+      .withBodyResponse(200, "TestObjectField", TestDto, {
+        extraFields: {
+          metadata: { type: TestDto },
+        },
+      })
+      .build();
+    const Target = applyDecoratorToMethod(decorator);
+    const ResponseType = getResponseType(Target, 200);
+
+    expect(ResponseType).toBeDefined();
+    const keys = getPropertyKeys(ResponseType.prototype);
+    expect(keys).toContain("metadata");
+
+    const meta = getPropertyMeta(ResponseType.prototype, "metadata");
+    expect(meta.type).toBe(TestDto);
+  });
+
+  it("should support array type [Type] in extraFields", () => {
+    const builder = new ApiDecoratorBuilder();
+
+    const decorator = builder
+      .withBodyResponse(200, "TestArrayField", TestDto, {
+        extraFields: {
+          items: { type: [TestDto] },
+        },
+      })
+      .build();
+    const Target = applyDecoratorToMethod(decorator);
+    const ResponseType = getResponseType(Target, 200);
+
+    expect(ResponseType).toBeDefined();
+    const keys = getPropertyKeys(ResponseType.prototype);
+    expect(keys).toContain("items");
+
+    const meta = getPropertyMeta(ResponseType.prototype, "items");
+    expect(meta.type).toBe(TestDto);
+    expect(meta.isArray).toBe(true);
+  });
+});

--- a/src/builders/api-decorator.builder.ts
+++ b/src/builders/api-decorator.builder.ts
@@ -5,7 +5,7 @@ import { createDetailResponse } from "../utils/create-detail-response";
 import { createStatusResponse } from "../utils/create-status-response";
 import { createExceptionResponse } from "../utils/create-exception-response";
 import { createFormDataRequest } from "../utils/create-form-data-request";
-import { ApiErrorResponse, ResponseOptions } from "../interfaces";
+import { ApiErrorResponse, ExtraFieldOptions, ResponseOptions } from "../interfaces";
 
 export type ApiOperationOptions = Required<Pick<Partial<OperationObject>, "summary">> &
   Partial<OperationObject>;
@@ -13,6 +13,7 @@ export type ApiOperationOptions = Required<Pick<Partial<OperationObject>, "summa
 export interface ApiDecoratorBuilderConfig {
   wrapperKey?: string | undefined;
   statusKey?: string | undefined;
+  extraFields?: Record<string, ExtraFieldOptions>;
 }
 
 /**
@@ -58,10 +59,16 @@ export class ApiDecoratorBuilder {
    * @returns Merged options
    */
   private getOptions<T extends Record<string, any>>(options: T = {} as T): T & ResponseOptions {
+    const mergedExtraFields =
+      this.config.extraFields || (options as any).extraFields
+        ? { ...this.config.extraFields, ...(options as any).extraFields }
+        : undefined;
+
     return {
       ...options,
       ...(this.config.statusKey !== undefined && { statusKey: this.config.statusKey }),
       ...(this.config.wrapperKey !== undefined && { wrapperKey: this.config.wrapperKey }),
+      ...(mergedExtraFields && { extraFields: mergedExtraFields }),
     } as T & ResponseOptions;
   }
 
@@ -111,6 +118,8 @@ export class ApiDecoratorBuilder {
   }
 
   build(): PropertyDecorator {
-    return applyDecorators(...this.decorators);
+    const result = applyDecorators(...this.decorators);
+    this.decorators = [];
+    return result;
   }
 }

--- a/src/interfaces/interface.ts
+++ b/src/interfaces/interface.ts
@@ -1,3 +1,4 @@
+import { Type } from "@nestjs/common";
 import { ApiResponseOptions } from "@nestjs/swagger";
 
 export interface ApiErrorResponse {
@@ -6,13 +7,20 @@ export interface ApiErrorResponse {
   description?: string;
 }
 
+export interface ExtraFieldOptions {
+  type: 'string' | 'number' | 'boolean' | Type | [Type];
+  example?: any;
+}
+
 /**
  * API Response Options
  *
  * @property statusKey - Status code field name in the response (when not set, status field will not be included)
  * @property wrapperKey - Data field name in the response (when not set, data field will not be included)
+ * @property extraFields - Additional fields to include in the response schema
  */
 export interface ResponseOptions extends Omit<ApiResponseOptions, "status" | "type"> {
   statusKey?: string;
   wrapperKey?: string;
+  extraFields?: Record<string, ExtraFieldOptions>;
 }

--- a/src/interfaces/interface.ts
+++ b/src/interfaces/interface.ts
@@ -3,7 +3,7 @@ import { ApiResponseOptions } from "@nestjs/swagger";
 
 export interface ApiErrorResponse {
   /**
-   * Swagger UI examples 의 라벨 key. 미지정 시 `error` 값을 fallback 으로 사용합니다.
+   * Label key for the Swagger UI examples entry. Falls back to `error` when omitted.
    */
   name?: string;
   error: string;

--- a/src/interfaces/interface.ts
+++ b/src/interfaces/interface.ts
@@ -2,7 +2,10 @@ import { Type } from "@nestjs/common";
 import { ApiResponseOptions } from "@nestjs/swagger";
 
 export interface ApiErrorResponse {
-  name: string;
+  /**
+   * Swagger UI examples 의 라벨 key. 미지정 시 `error` 값을 fallback 으로 사용합니다.
+   */
+  name?: string;
   error: string;
   description?: string;
 }

--- a/src/utils/create-detail-response.ts
+++ b/src/utils/create-detail-response.ts
@@ -14,11 +14,11 @@ export function createDetailResponse(
   type: Type | Type[],
   options: ResponseOptions = {}
 ) {
-  const { wrapperKey, statusKey, ...responseOptions } = options;
+  const { wrapperKey, statusKey, extraFields, ...responseOptions } = options;
   const isTypeArray = isArray(type);
   const resolvedType = isTypeArray ? type[0] : type;
 
-  if (!wrapperKey && !statusKey) {
+  if (!wrapperKey && !statusKey && !extraFields) {
     return applyDecorators(
       isTypeArray ? ApiExtraModels(...type) : ApiExtraModels(type),
       ApiResponse({
@@ -30,6 +30,24 @@ export function createDetailResponse(
   }
 
   class DetailResponseClass {}
+
+  if (extraFields) {
+    for (const [fieldKey, fieldOptions] of Object.entries(extraFields)) {
+      const isFieldArray = Array.isArray(fieldOptions.type);
+      const rawType = isFieldArray ? (fieldOptions.type as any[])[0] : fieldOptions.type;
+      const resolvedFieldType =
+        rawType === 'boolean' ? Boolean
+        : rawType === 'number' ? Number
+        : rawType === 'string' ? String
+        : rawType;
+
+      defineProperty(DetailResponseClass.prototype, fieldKey, {
+        type: resolvedFieldType,
+        ...(isFieldArray && { isArray: true }),
+        ...(fieldOptions.example !== undefined && { example: fieldOptions.example }),
+      });
+    }
+  }
 
   if (statusKey) {
     defineProperty(DetailResponseClass.prototype, statusKey, {
@@ -46,6 +64,12 @@ export function createDetailResponse(
 
   if (wrapperKey) {
     defineProperty(DetailResponseClass.prototype, wrapperKey, {
+      type,
+    });
+  }
+
+  if (!statusKey && !wrapperKey) {
+    defineProperty(DetailResponseClass.prototype, "data", {
       type,
     });
   }

--- a/src/utils/create-exception-response.ts
+++ b/src/utils/create-exception-response.ts
@@ -13,14 +13,15 @@ export function createExceptionResponse(status: ErrorHttpStatusCode, errors: Api
   const examples: Record<string, any> = {};
 
   errors.forEach(({ name, error, description }) => {
-    examples[name] = { value: { status, error, description } };
+    const key = name ?? error;
+    examples[key] = { value: { status, error, description } };
   });
 
   return applyDecorators(
     ApiResponse({
       status,
       content: {
-        "application-json": {
+        "application/json": {
           examples,
         },
       },

--- a/src/utils/create-status-response.ts
+++ b/src/utils/create-status-response.ts
@@ -17,9 +17,9 @@ export function createStatusResponse(
   key: string,
   options: Omit<ResponseOptions, "wrapperKey"> = {}
 ) {
-  const { statusKey, ...responseOptions } = options;
+  const { statusKey, extraFields, ...responseOptions } = options;
 
-  if (!statusKey) {
+  if (!statusKey && !extraFields) {
     return ApiResponse({
       status,
       ...responseOptions,
@@ -27,10 +27,31 @@ export function createStatusResponse(
   }
 
   class StatusResponseClass {}
-  defineProperty(StatusResponseClass.prototype, statusKey, {
-    enum: HttpStatus,
-    example: status,
-  });
+
+  if (extraFields) {
+    for (const [fieldKey, fieldOptions] of Object.entries(extraFields)) {
+      const isFieldArray = Array.isArray(fieldOptions.type);
+      const rawType = isFieldArray ? (fieldOptions.type as any[])[0] : fieldOptions.type;
+      const resolvedFieldType =
+        rawType === 'boolean' ? Boolean
+        : rawType === 'number' ? Number
+        : rawType === 'string' ? String
+        : rawType;
+
+      defineProperty(StatusResponseClass.prototype, fieldKey, {
+        type: resolvedFieldType,
+        ...(isFieldArray && { isArray: true }),
+        ...(fieldOptions.example !== undefined && { example: fieldOptions.example }),
+      });
+    }
+  }
+
+  if (statusKey) {
+    defineProperty(StatusResponseClass.prototype, statusKey, {
+      enum: HttpStatus,
+      example: status,
+    });
+  }
 
   setClassName(StatusResponseClass, `${key[0].toUpperCase()}${key.slice(1)}StatusResponseDto`);
 


### PR DESCRIPTION
## Summary

This PR bundles two related changes that emerged while wiring `extraFields` into a downstream project.

### 1. New: `extraFields` response option
- Add `extraFields` option to include arbitrary key-value fields in Swagger response schemas
- Support primitive types (`string`, `number`, `boolean`), DTO classes (`Type`), and arrays (`[Type]`)
- Config-level `extraFields` serve as defaults, endpoint-level `extraFields` override on merge
- `extraFields` works standalone without `statusKey`/`wrapperKey`
- Fully backward compatible (no changes when `extraFields` is not used)

### 2. Fixes for `withException` family
- Make `ApiErrorResponse.name` **optional**. When omitted, the example key falls back to `error` (matches 1.0.3 behavior). Existing callers that pass only `{ error, description }` keep working.
- Fix `application-json` typo in `createExceptionResponse` content-type. Now emits the standard `application/json`. Swagger UI renders examples correctly under the proper media type.

## Changed Files
- `src/interfaces/interface.ts` — Add `ExtraFieldOptions`; add `extraFields` to `ResponseOptions`; make `ApiErrorResponse.name` optional
- `src/builders/api-decorator.builder.ts` — Add `extraFields` to config, merge logic in `getOptions()`
- `src/utils/create-detail-response.ts` — Render `extraFields` via `defineProperty()`
- `src/utils/create-status-response.ts` — Render `extraFields` via `defineProperty()`
- `src/utils/create-exception-response.ts` — Fall back to `error` when `name` is omitted; emit `application/json`
- `examples/` — Add multiple preset builder examples
- `package.json` — Bump version 1.0.1 → 1.1.0-beta.1

## Beta release
Already published as `1.1.0-beta.0` and `1.1.0-beta.1` on npm with the `beta` dist-tag for downstream verification. After merge, will be republished as `1.1.0` (latest) once verified in the downstream project.

## Test plan
- [x] Config `extraFields` applied to `withBodyResponse` schema
- [x] Per-endpoint `extraFields` applied
- [x] Config + endpoint merge with endpoint priority
- [x] Standalone `extraFields` creates wrapper class
- [x] `extraFields` applied to `withStatusResponse` schema
- [x] `extraFields` combined with `wrapperKey`
- [x] No `extraFields` behaves as before
- [x] `Type` (class) supported in `extraFields`
- [x] Array type `[Type]` supported in `extraFields`
- [x] `build()` state reset tests still pass
- [x] `withException` uses `error` code as fallback key when `name` is omitted
- [x] `withException` uses explicit `name` as key when provided
- [x] `withException` mixes `name` and fallback keys within the same call
- [x] Examples emitted under standard `application/json` content-type